### PR TITLE
Serde Debugability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ anyhow = "1.0.31"
 byteorder = "1.3.2"
 paste = "1.0"
 thiserror = "1"
+serde = { version = "1", features = ["derive"], optional = true }
+
+[features]
+serde = ["dep:serde"]

--- a/src/nla.rs
+++ b/src/nla.rs
@@ -4,6 +4,8 @@ use core::ops::Range;
 
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 
 use crate::{
     traits::{Emitable, Parseable},
@@ -178,6 +180,8 @@ impl<'buffer, T: AsRef<[u8]> + AsMut<[u8]> + ?Sized> NlaBuffer<&'buffer mut T> {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+
 pub struct DefaultNla {
     kind: u16,
     value: Vec<u8>,


### PR DESCRIPTION
For testing purposes, it would be nice to be able to serialize and deserialize packets in a human readable format. This adds an optional feature to derive the serialize and deserialize `impl`s from the [serde](https://docs.rs/serde/1.0.164/serde/) crate