### PR TITLE
Use thiserror Errors instead of relying on anyhow

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,29 +32,49 @@ impl From<anyhow::Error> for EncodeError {
 }
 
 #[derive(Debug, Error)]
-#[error("Decode error occurred: {inner}")]
-pub struct DecodeError {
-    inner: anyhow::Error,
+pub enum DecodeError {
+    #[error(
+        "Invalid MAC address. Expected 6 bytes, received {received} bytes"
+    )]
+    InvalidMACAddress { received: usize },
+
+    #[error(
+        "Invalid IP address. Expected 4 or 16 bytes, received {received} bytes"
+    )]
+    InvalidIPAddress { received: usize },
+
+    #[error("Invalid string")]
+    Utf8Error(#[from] std::string::FromUtf8Error),
+
+    #[error(
+        "Invalid number. Expected {expected} bytes, received {received} bytes"
+    )]
+    InvalidNumber { expected: usize, received: usize },
+
+    #[error("Invalid buffer {name}. Expected at least {minimum_length} bytes, received {received} bytes")]
+    InvalidBuffer {
+        name: &'static str,
+        received: usize,
+        minimum_length: usize,
+    },
+
+    #[error(transparent)]
+    Nla(#[from] crate::nla::NlaError),
+
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error>),
 }
 
-impl From<&'static str> for DecodeError {
-    fn from(msg: &'static str) -> Self {
-        DecodeError {
-            inner: anyhow!(msg),
-        }
+impl From<&str> for DecodeError {
+    fn from(msg: &str) -> Self {
+        let error: Box<dyn std::error::Error> = msg.to_string().into();
+        DecodeError::Other(error)
     }
 }
 
 impl From<String> for DecodeError {
     fn from(msg: String) -> Self {
-        DecodeError {
-            inner: anyhow!(msg),
-        }
-    }
-}
-
-impl From<anyhow::Error> for DecodeError {
-    fn from(inner: anyhow::Error) -> DecodeError {
-        DecodeError { inner }
+        let error: Box<dyn std::error::Error> = msg.into();
+        DecodeError::Other(error)
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -192,15 +192,11 @@ macro_rules! buffer_check_length {
             fn check_buffer_length(&self) -> Result<(), DecodeError> {
                 let len = self.buffer.as_ref().len();
                 if len < $buffer_len {
-                    Err(format!(
-                        concat!(
-                            "invalid ",
-                            stringify!($name),
-                            ": length {} < {}"
-                        ),
-                        len, $buffer_len
-                    )
-                    .into())
+                    Err(DecodeError::InvalidBuffer {
+                        name: stringify!($name),
+                        received: len,
+                        minimum_length: $buffer_len,
+                    })
                 } else {
                     Ok(())
                 }

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -5,14 +5,15 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
-use anyhow::Context;
 use byteorder::{BigEndian, ByteOrder, NativeEndian};
 
 use crate::DecodeError;
 
 pub fn parse_mac(payload: &[u8]) -> Result<[u8; 6], DecodeError> {
     if payload.len() != 6 {
-        return Err(format!("invalid MAC address: {payload:?}").into());
+        return Err(DecodeError::InvalidMACAddress {
+            received: payload.len(),
+        });
     }
     let mut address: [u8; 6] = [0; 6];
     for (i, byte) in payload.iter().enumerate() {
@@ -23,7 +24,9 @@ pub fn parse_mac(payload: &[u8]) -> Result<[u8; 6], DecodeError> {
 
 pub fn parse_ipv6(payload: &[u8]) -> Result<[u8; 16], DecodeError> {
     if payload.len() != 16 {
-        return Err(format!("invalid IPv6 address: {payload:?}").into());
+        return Err(DecodeError::InvalidIPAddress {
+            received: payload.len(),
+        });
     }
     let mut address: [u8; 16] = [0; 16];
     for (i, byte) in payload.iter().enumerate() {
@@ -57,7 +60,7 @@ pub fn parse_ip(payload: &[u8]) -> Result<IpAddr, DecodeError> {
             payload[15],
         ])
         .into()),
-        _ => Err(format!("invalid IPv6 address: {payload:?}").into()),
+        other => Err(DecodeError::InvalidIPAddress { received: other }),
     }
 }
 
@@ -71,62 +74,86 @@ pub fn parse_string(payload: &[u8]) -> Result<String, DecodeError> {
     } else {
         &payload[..payload.len()]
     };
-    let s = String::from_utf8(slice.to_vec()).context("invalid string")?;
+    let s = String::from_utf8(slice.to_vec())?;
     Ok(s)
 }
 
 pub fn parse_u8(payload: &[u8]) -> Result<u8, DecodeError> {
     if payload.len() != 1 {
-        return Err(format!("invalid u8: {payload:?}").into());
+        return Err(DecodeError::InvalidNumber {
+            expected: 1,
+            received: payload.len(),
+        });
     }
     Ok(payload[0])
 }
 
 pub fn parse_u32(payload: &[u8]) -> Result<u32, DecodeError> {
     if payload.len() != size_of::<u32>() {
-        return Err(format!("invalid u32: {payload:?}").into());
+        return Err(DecodeError::InvalidNumber {
+            expected: size_of::<u32>(),
+            received: payload.len(),
+        });
     }
     Ok(NativeEndian::read_u32(payload))
 }
 
 pub fn parse_u64(payload: &[u8]) -> Result<u64, DecodeError> {
     if payload.len() != size_of::<u64>() {
-        return Err(format!("invalid u64: {payload:?}").into());
+        return Err(DecodeError::InvalidNumber {
+            expected: size_of::<u64>(),
+            received: payload.len(),
+        });
     }
     Ok(NativeEndian::read_u64(payload))
 }
 
 pub fn parse_u128(payload: &[u8]) -> Result<u128, DecodeError> {
     if payload.len() != size_of::<u128>() {
-        return Err(format!("invalid u128: {payload:?}").into());
+        return Err(DecodeError::InvalidNumber {
+            expected: size_of::<u128>(),
+            received: payload.len(),
+        });
     }
     Ok(NativeEndian::read_u128(payload))
 }
 
 pub fn parse_u16(payload: &[u8]) -> Result<u16, DecodeError> {
     if payload.len() != size_of::<u16>() {
-        return Err(format!("invalid u16: {payload:?}").into());
+        return Err(DecodeError::InvalidNumber {
+            expected: size_of::<u16>(),
+            received: payload.len(),
+        });
     }
     Ok(NativeEndian::read_u16(payload))
 }
 
 pub fn parse_i32(payload: &[u8]) -> Result<i32, DecodeError> {
     if payload.len() != 4 {
-        return Err(format!("invalid u32: {payload:?}").into());
+        return Err(DecodeError::InvalidNumber {
+            expected: 4,
+            received: payload.len(),
+        });
     }
     Ok(NativeEndian::read_i32(payload))
 }
 
 pub fn parse_u16_be(payload: &[u8]) -> Result<u16, DecodeError> {
     if payload.len() != size_of::<u16>() {
-        return Err(format!("invalid u16: {payload:?}").into());
+        return Err(DecodeError::InvalidNumber {
+            expected: size_of::<u16>(),
+            received: payload.len(),
+        });
     }
     Ok(BigEndian::read_u16(payload))
 }
 
 pub fn parse_u32_be(payload: &[u8]) -> Result<u32, DecodeError> {
     if payload.len() != size_of::<u32>() {
-        return Err(format!("invalid u32: {payload:?}").into());
+        return Err(DecodeError::InvalidNumber {
+            expected: size_of::<u32>(),
+            received: payload.len(),
+        });
     }
     Ok(BigEndian::read_u32(payload))
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-use crate::DecodeError;
-
 /// A type that implements `Emitable` can be serialized.
 pub trait Emitable {
     /// Return the length of the serialized data.
@@ -26,8 +24,10 @@ where
     Self: Sized,
     T: ?Sized,
 {
+    type Error;
+
     /// Deserialize the current type.
-    fn parse(buf: &T) -> Result<Self, DecodeError>;
+    fn parse(buf: &T) -> Result<Self, Self::Error>;
 }
 
 /// A `Parseable` type can be used to deserialize data from the type `T` for
@@ -37,6 +37,8 @@ where
     Self: Sized,
     T: ?Sized,
 {
+    type Error;
+
     /// Deserialize the current type.
-    fn parse_with_param(buf: &T, params: P) -> Result<Self, DecodeError>;
+    fn parse_with_param(buf: &T, params: P) -> Result<Self, Self::Error>;
 }


### PR DESCRIPTION
This improves matching on particular errors when we need to handle them differently downstream. At the moment we would need to be matching error strings which is brittle and not ideal.

For now I left the possibility of converting a `anyhow::Error` to a `DecodeError` in this change, but every other error this crate exposes is now a variant of `DecodeError`. I've left `EncodeError` untouched.

I'm preparing a change on top of this one in the netlink-packet-route crate as well that makes that create expose more granular errors that can be matched against.

Bug #10 