### PR TITLE
Remove the use of anyhow in EncodeError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 
 
 [dependencies]
-anyhow = "1.0.31"
 byteorder = "1.3.2"
 pastey = "0.1.0"
 thiserror = "2"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum EncodeError {
     #[error(transparent)]
     Other(#[from] Box<dyn std::error::Error>),
@@ -23,6 +24,7 @@ impl From<String> for EncodeError {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum DecodeError {
     #[error(
         "Invalid MAC address. Expected 6 bytes, received {received} bytes"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,33 +1,24 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::anyhow;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-#[error("Encode error occurred: {inner}")]
-pub struct EncodeError {
-    inner: anyhow::Error,
+pub enum EncodeError {
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error>),
 }
 
-impl From<&'static str> for EncodeError {
-    fn from(msg: &'static str) -> Self {
-        EncodeError {
-            inner: anyhow!(msg),
-        }
+impl From<&str> for EncodeError {
+    fn from(msg: &str) -> Self {
+        let error: Box<dyn std::error::Error> = msg.to_string().into();
+        EncodeError::Other(error)
     }
 }
 
 impl From<String> for EncodeError {
     fn from(msg: String) -> Self {
-        EncodeError {
-            inner: anyhow!(msg),
-        }
-    }
-}
-
-impl From<anyhow::Error> for EncodeError {
-    fn from(inner: anyhow::Error) -> EncodeError {
-        EncodeError { inner }
+        let error: Box<dyn std::error::Error> = msg.into();
+        EncodeError::Other(error)
     }
 }
 


### PR DESCRIPTION
Changed `EncodeError` from `struct` to `enum` and remove the use of
anyhow but using thiserror instead.